### PR TITLE
Be compatible with mirage.4.6.0 and http-mirage-client.0.0.6

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,10 +1,10 @@
 freebsd_instance:
-  image_family: freebsd-13-2
+  image_family: freebsd-14-1
 
 freebsd_task:
   pkg_install_script: pkg install -y ocaml-opam gmake bash
-  ocaml_script: opam init -a --comp=4.13.1
-  mirage_script: eval `opam env` && opam install --confirm-level=unsafe-yes "mirage>=4.5.0"
+  ocaml_script: opam init -a --comp=4.14.1
+  mirage_script: eval `opam env` && opam install --confirm-level=unsafe-yes "mirage>=4.6.0"
   configure_script: eval `opam env` && mirage configure -t hvt
   depend_script: eval `opam env` && gmake depend
   build_script: eval `opam env` && gmake build
@@ -14,7 +14,7 @@ freebsd_task:
 freebsd_monitoring_task:
   pkg_install_script: pkg install -y ocaml-opam gmake bash
   ocaml_script: opam init -a --comp=4.14.1
-  mirage_script: eval `opam env` && opam install --confirm-level=unsafe-yes "mirage>=4.5.0"
+  mirage_script: eval `opam env` && opam install --confirm-level=unsafe-yes "mirage>=4.6.0"
   configure_script: eval `opam env` && mirage configure -t hvt --enable-monitoring
   depend_script: eval `opam env` && gmake depend
   build_script: eval `opam env` && gmake build

--- a/config.ml
+++ b/config.ml
@@ -1,4 +1,4 @@
-(* mirage >= 4.5.1 & < 4.6.0 *)
+(* mirage >= 4.6.0 & < 4.6.1 *)
 
 open Mirage
 
@@ -15,7 +15,7 @@ let packages = [
   package "awa-mirage";
   package ~min:"0.3.0" "letsencrypt";
   package ~min:"0.5.0" "paf" ~sublibs:[ "mirage" ];
-  package ~min:"0.0.3" "http-mirage-client";
+  package ~min:"0.0.6" "http-mirage-client";
   package "letsencrypt-mirage";
   package "ohex";
 ]
@@ -92,12 +92,11 @@ let optional_syslog pclock stack =
     (syslog $ pclock $ stack)
     noop
 
-let dns = generic_dns_client stack
+let he = generic_happy_eyeballs stack
+let dns = generic_dns_client stack he
 
 let alpn_client =
-  let dns =
-    mimic_happy_eyeballs stack dns (generic_happy_eyeballs stack dns)
-  in
+  let dns = mimic_happy_eyeballs stack he dns in
   paf_client (tcpv4v6_of_stackv4v6 stack) dns
 
 let ssh_key =
@@ -127,7 +126,7 @@ let tls_authenticator =
      Arg.(value & opt (some string) None doc)|}
 
 let git_client =
-  let git = mimic_happy_eyeballs stack dns (generic_happy_eyeballs stack dns) in
+  let git = mimic_happy_eyeballs stack he dns in
   let tcp = tcpv4v6_of_stackv4v6 stack in
   merge_git_clients (git_tcp tcp git)
     (merge_git_clients (git_ssh ~key:ssh_key ~password:ssh_password ~authenticator:ssh_authenticator tcp git)

--- a/config.ml
+++ b/config.ml
@@ -1,4 +1,4 @@
-(* mirage >= 4.6.0 & < 4.6.1 *)
+(* mirage >= 4.6.0 & < 4.7.0 *)
 
 open Mirage
 


### PR DESCRIPTION
Waiting for a release of `http-mirage-client` and ready to merge (actually deployed locally on my machine).